### PR TITLE
replace https with http

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -23,7 +23,7 @@
 
   <body>
     <links>
-      <item name="Issues" href="https://github.com/opengeospatial/ets-wms130/issues"/>
+      <item name="Issues" href="http://github.com/opengeospatial/ets-wms130/issues"/>
     </links>
     <menu name="Documentation">
       <item href="index.html" name="Overview" />


### PR DESCRIPTION
Please avoid URL with SSL. The Apache Maven Site Plugin has some problems with URL with ```https```. The URL starting with ```https``` will be interpreted as an internal URL.