### PR TITLE
Fixed XPath to detect layer CRS (also consider root layer)

### DIFF
--- a/src/main/scripts/ctl/functions.xml
+++ b/src/main/scripts/ctl/functions.xml
@@ -56,14 +56,14 @@
 
          <xsl:variable name="crs">
             <xsl:choose>
-               <xsl:when test="$root-layer//wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer[wms:CRS = $preferred-crs]">
+               <xsl:when test="$root-layer/descendant-or-self::wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer[wms:CRS = $preferred-crs]">
                   <xsl:value-of select="$preferred-crs"/>
                </xsl:when>
-               <xsl:when test="$root-layer//wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer/wms:BoundingBox">
-                  <xsl:value-of select="$root-layer//wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer[1]/wms:BoundingBox[1]/@CRS"/>
+               <xsl:when test="$root-layer/descendant-or-self::wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer/wms:BoundingBox">
+                  <xsl:value-of select="$root-layer/descendant-or-self::wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer[1]/wms:BoundingBox[1]/@CRS"/>
                </xsl:when>
-               <xsl:when test="$root-layer//wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer/wms:CRS">
-                  <xsl:value-of select="$root-layer//wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer[1]/wms:CRS[1]"/>
+               <xsl:when test="$root-layer/descendant-or-self::wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer/wms:CRS">
+                  <xsl:value-of select="$root-layer/descendant-or-self::wms:Layer[wms:Name = $layer-name]/ancestor-or-self::wms:Layer[1]/wms:CRS[1]"/>
                </xsl:when>
                <xsl:otherwise>NoCRSForLayer</xsl:otherwise>
             </xsl:choose>


### PR DESCRIPTION
Previously, the root layer was not considered when detecting CRS. The XPath was fixed to include the root layer.

Without the fix following tests failed due to this issue, when testing a WMS with just one layer (see #14):
bbox-direct
crs-direct
each-style
first-style-invalid
second-style-invalid
styles-direct
styles-inherited
styles-some-default
three-styles
two-styles