### PR TITLE
Fixed XPath to prevent selection of multiple layers

### DIFF
--- a/src/main/scripts/ctl/getmap.xml
+++ b/src/main/scripts/ctl/getmap.xml
@@ -844,7 +844,7 @@
     <ctl:link title="WMS 1.3.0 section 7.3.3.6">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.bbox</ctl:link>
     <ctl:code>
       <xsl:variable name="image-format" select="wms:Capability/wms:Request/wms:GetMap/wms:Format[starts-with(., 'image/png') or starts-with(., 'image/gif')][1]"/>
-      <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84'] and position()=1]/wms:Name)"/>
+      <xsl:variable name="layer" select="string(wms:Capability/descendant::wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84']][1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$layer = ''">
           <ctl:message>No named CRS:84 layers.</ctl:message>
@@ -1122,7 +1122,7 @@
     <ctl:link title="WMS 1.3.0 section 7.3.3.5">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.crs</ctl:link>
     <ctl:code>
       <xsl:variable name="image-format" select="wms:Capability/wms:Request/wms:GetMap/wms:Format[1]"/>
-      <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[1]/wms:Name)"/>
+      <xsl:variable name="layer" select="string(wms:Capability/descendant::wms:Layer[wms:Name and wms:Name/text() != ''][1]/wms:Name)"/>
       <xsl:variable name="response">
         <ctl:request>
           <ctl:url>

--- a/src/main/scripts/ctl/getmap.xml
+++ b/src/main/scripts/ctl/getmap.xml
@@ -226,7 +226,7 @@
     <ctl:comment/>
     <ctl:link title="WMS 1.3.0 section 7.3.3.6">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.bbox</ctl:link>
     <ctl:code>
-      <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[wms:Name and wms:BoundingBox][1]/wms:Name)"/>
+      <xsl:variable name="layer" select="string(wms:Capability/descendant::wms:Layer[wms:Name and wms:BoundingBox][1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$layer = ''">
           <ctl:message>No named layers with a BoundingBox contained directly in the layer.</ctl:message>
@@ -293,7 +293,7 @@
     <ctl:comment/>
     <ctl:link title="WMS 1.3.0 section 7.3.3.6">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.bbox</ctl:link>
     <ctl:code>
-      <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[wms:Name and not(wms:BoundingBox) and ancestor::wms:Layer/wms:BoundingBox][1]/wms:Name)"/>
+      <xsl:variable name="layer" select="string(wms:Capability/descendant::wms:Layer[wms:Name and not(wms:BoundingBox) and ancestor::wms:Layer/wms:BoundingBox][1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$layer = ''">
           <ctl:message>No named layers with an inherited BoundingBox.</ctl:message>
@@ -362,13 +362,13 @@
     <ctl:link title="WMS 1.3.0 section 7.2.4.6.9">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getcapabilities.response.layer_properties.scale_denominators</ctl:link>
     <ctl:code>
       <xsl:variable name="image-format" select="string(wms:Capability/wms:Request/wms:GetMap/wms:Format[1])"/>
-      <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84'] and number(ancestor-or-self::wms:Layer/wms:MinScaleDenominator) &gt; 0][1]/wms:Name)"/>
+      <xsl:variable name="layer" select="string(wms:Capability/descendant::wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84'] and number(ancestor-or-self::wms:Layer/wms:MinScaleDenominator) &gt; 0][1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$layer = ''">
           <ctl:message>No named CRS:84 layers with a minimum scale denominator greater than 0.</ctl:message>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:variable name="min-scale-denominator" select="number(wms:Capability//wms:Layer[wms:Name=$layer]/ancestor-or-self::wms:Layer/wms:MinScaleDenominator[number(.) &gt; 0][1])"/>
+          <xsl:variable name="min-scale-denominator" select="number(wms:Capability/descendant::wms:Layer[wms:Name=$layer]/ancestor-or-self::wms:Layer/wms:MinScaleDenominator[number(.) &gt; 0][1])"/>
           <xsl:variable name="pixel-size" select="number(200)"/>
           <!-- Calculate the size for a bbox with a scale denominator that is 90% of the minimum scale denominator -->
           <xsl:variable name="bbox-size" select="number(($min-scale-denominator * .9 * 0.00028 * $pixel-size * 360) div (6378137 * 2 * 3.14159265))"/>
@@ -410,13 +410,13 @@
     <ctl:link title="WMS 1.3.0 section 7.2.4.6.9">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getcapabilities.response.layer_properties.scale_denominators</ctl:link>
     <ctl:code>
       <xsl:variable name="image-format" select="string(wms:Capability/wms:Request/wms:GetMap/wms:Format[1])"/>
-      <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84'] and ancestor-or-self::wms:Layer/wms:MaxScaleDenominator][1]/wms:Name)"/>
+      <xsl:variable name="layer" select="string(wms:Capability/descendant::wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84'] and ancestor-or-self::wms:Layer/wms:MaxScaleDenominator][1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$layer = ''">
           <ctl:message>No named CRS:84 layers with a maximum scale denominator.</ctl:message>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:variable name="max-scale-denominator" select="number(wms:Capability//wms:Layer[wms:Name=$layer]/ancestor-or-self::wms:Layer/wms:MaxScaleDenominator[1])"/>
+          <xsl:variable name="max-scale-denominator" select="number(wms:Capability/descendant::wms:Layer[wms:Name=$layer]/ancestor-or-self::wms:Layer/wms:MaxScaleDenominator[1])"/>
           <xsl:variable name="pixel-size" select="number(200)"/>
           <!-- Calculate the size for a bbox with a scale denominator that is 110% of the maximum scale denominator -->
           <xsl:variable name="bbox-size" select="number(($max-scale-denominator * 1.1 * 0.00028 * $pixel-size * 360) div (6378137 * 2 * 3.14159265))"/>
@@ -792,7 +792,7 @@
     <ctl:link title="WMS 1.3.0 section 7.3.3.6">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.bbox</ctl:link>
     <ctl:code>
       <xsl:variable name="image-format" select="wms:Capability/wms:Request/wms:GetMap/wms:Format[starts-with(., 'image/png') or starts-with(., 'image/gif')][1]"/>
-      <xsl:variable name="geobbox" select="wms:Capability//wms:Layer/wms:EX_GeographicBoundingBox[wms:westBoundLongitude &gt; -180 and wms:southBoundLongitude &gt; -90][1]"/>
+      <xsl:variable name="geobbox" select="wms:Capability/descendant::wms:Layer/wms:EX_GeographicBoundingBox[wms:westBoundLongitude &gt; -180 and wms:southBoundLongitude &gt; -90][1]"/>
       <xsl:variable name="x" select="$geobbox/wms:EX_GeographicBoundingBox/wms:westBoundLongitude"/>
       <xsl:variable name="y" select="$geobbox/wms:EX_GeographicBoundingBox/wms:southBoundLatitude"/>
       <xsl:variable name="layer" select="string(wms:Capability//wms:Layer[wms:Name and ancestor-or-self::wms:Layer[wms:CRS='CRS:84'] and ancestor-or-self::wms:Layer[wms:EX_GeographicBoundingBox[wms:westBoundLongitude = $x and wms:southBoundLongitude = $y]]]/wms:Name)"/>
@@ -987,7 +987,7 @@
     <ctl:comment/>
     <ctl:link title="WMS 1.3.0 section 7.3.3.5">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.crs</ctl:link>
     <ctl:code>
-      <xsl:variable name="crs" select="string(wms:Capability//wms:Layer[wms:Name and position()=last()]/wms:CRS[1])"/>
+      <xsl:variable name="crs" select="string(wms:Capability/descendant::wms:Layer[wms:Name][last()]/wms:CRS[1])"/>
       <xsl:choose>
         <xsl:when test="$crs = ''">
           <ctl:message>Error: No Named layers with a CRS contained directly in the layer.</ctl:message>
@@ -997,7 +997,7 @@
           <xsl:variable name="layer-info">
             <ctl:call-function name="functions:layer-info">
               <ctl:with-param name="root-layer" select="wms:Capability/wms:Layer"/>
-              <ctl:with-param name="preferred-name" select="string(wms:Capability//wms:Layer[wms:CRS=$crs and position()=last()]/wms:Name)"/>
+              <ctl:with-param name="preferred-name" select="string(wms:Capability/descendant::wms:Layer[wms:CRS=$crs][last()]/wms:Name)"/>
               <ctl:with-param name="preferred-crs" select="$crs"/>
               <ctl:with-param name="preferred-bbox"/>
               <ctl:with-param name="preferred-width">200</ctl:with-param>
@@ -1054,7 +1054,7 @@
     <ctl:comment/>
     <ctl:link title="WMS 1.3.0 section 7.3.3.5">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.crs</ctl:link>
     <ctl:code>
-      <xsl:variable name="crs" select="string(wms:Capability//wms:Layer[wms:Name]/ancestor::wms:Layer/wms:CRS[1])"/>
+      <xsl:variable name="crs" select="string(wms:Capability/descendant::wms:Layer[wms:Name][1]/ancestor::wms:Layer/wms:CRS[1])"/>
       <xsl:choose>
         <xsl:when test="$crs = ''">
           <ctl:message>Error: No Named layers with a CRS inherited from a parent layer.</ctl:message>
@@ -1064,7 +1064,7 @@
           <xsl:variable name="layer-info">
             <ctl:call-function name="functions:layer-info">
               <ctl:with-param name="root-layer" select="wms:Capability/wms:Layer"/>
-              <ctl:with-param name="preferred-name" select="string(wms:Capability//wms:Layer[wms:Name and ancestor::wms:Layer/wms:CRS=$crs][1]/wms:Name)"/>
+              <ctl:with-param name="preferred-name" select="string(wms:Capability/descendant::wms:Layer[wms:Name and ancestor::wms:Layer/wms:CRS=$crs][1]/wms:Name)"/>
               <ctl:with-param name="preferred-crs" select="$crs"/>
               <ctl:with-param name="preferred-bbox"/>
               <ctl:with-param name="preferred-width">200</ctl:with-param>
@@ -1990,7 +1990,7 @@
     <ctl:comment/>
     <ctl:link title="WMS 1.3.0 section 7.2.4.6.5">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.styles</ctl:link>
     <ctl:code>
-      <xsl:variable name="style" select="string(wms:Capability//wms:Layer[wms:Name and position()=1]/wms:Style[1]/wms:Name)"/>
+      <xsl:variable name="style" select="string(wms:Capability/descendant::wms:Layer[wms:Name][1]/wms:Style[1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$style = ''">
           <ctl:message>No named layers with a style contained directly in the layer.</ctl:message>
@@ -2001,7 +2001,7 @@
             <ctl:call-function name="functions:layer-info">
               <ctl:with-param name="root-layer" select="wms:Capability/wms:Layer"/>
               <!-- select last layer in list -->
-              <ctl:with-param name="preferred-name" select="string(wms:Capability//wms:Layer[wms:Name and wms:Style/wms:Name = $style and position()=last()]/wms:Name)"/>
+              <ctl:with-param name="preferred-name" select="string(wms:Capability/descendant::wms:Layer[wms:Name and wms:Style/wms:Name = $style][last()]/wms:Name)"/>
               <ctl:with-param name="preferred-crs">CRS:84</ctl:with-param>
               <ctl:with-param name="preferred-bbox">-0.0025,-0.0025,0.0025,0.0025</ctl:with-param>
               <ctl:with-param name="preferred-width">100</ctl:with-param>
@@ -2130,7 +2130,7 @@
     <ctl:link title="WMS 1.3.0 section 7.2.4.6.5">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.styles</ctl:link>
     <ctl:code>
       <xsl:variable name="style" 
-      select="string(wms:Capability//wms:Layer[wms:Name and position()=1]/ancestor-or-self::wms:Layer[1]/wms:Style[1]/wms:Name)"/>
+      select="string(wms:Capability/descendant::wms:Layer[wms:Name][1]/ancestor-or-self::wms:Layer[1]/wms:Style[1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$style = ''">
           <ctl:message>No named layers with a style.</ctl:message>
@@ -2141,7 +2141,7 @@
             <ctl:call-function name="functions:layer-info">
               <ctl:with-param name="root-layer" select="wms:Capability/wms:Layer"/>
               <!-- select last layer in list -->
-              <ctl:with-param name="preferred-name" select="string(wms:Capability//wms:Layer[wms:Name and wms:Style/wms:Name = $style and position()=last()]/wms:Name)"/>
+              <ctl:with-param name="preferred-name" select="string(wms:Capability/descendant::wms:Layer[wms:Name and wms:Style/wms:Name = $style][last()]/wms:Name)"/>
               <ctl:with-param name="preferred-crs">CRS:84</ctl:with-param>
               <ctl:with-param name="preferred-bbox">-0.0025,-0.0025,0.0025,0.0025</ctl:with-param>
               <ctl:with-param name="preferred-width">100</ctl:with-param>
@@ -2203,7 +2203,7 @@
     <ctl:link title="WMS 1.3.0 section 7.2.4.6.5">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.styles</ctl:link>
     <ctl:code>
       <xsl:variable name="style" 
-      select="string(wms:Capability//wms:Layer[wms:Name and position()=1]/ancestor-or-self::wms:Layer[1]/wms:Style[1]/wms:Name)"/>
+      select="string(wms:Capability/descendant::wms:Layer[wms:Name][1]/ancestor-or-self::wms:Layer[1]/wms:Style[1]/wms:Name)"/>
       <xsl:choose>
         <xsl:when test="$style = ''">
           <ctl:message>No named layers with a style.</ctl:message>
@@ -2214,7 +2214,7 @@
             <ctl:call-function name="functions:layer-info">
               <ctl:with-param name="root-layer" select="wms:Capability/wms:Layer"/>
               <!-- select last layer in list -->
-              <ctl:with-param name="preferred-name" select="string(wms:Capability//wms:Layer[wms:Name and wms:Style/wms:Name = $style and position()=last()]/wms:Name)"/>
+              <ctl:with-param name="preferred-name" select="string(wms:Capability/descendant::wms:Layer[wms:Name and wms:Style/wms:Name = $style][last()]/wms:Name)"/>
               <ctl:with-param name="preferred-crs">CRS:84</ctl:with-param>
               <ctl:with-param name="preferred-bbox">-0.0025,-0.0025,0.0025,0.0025</ctl:with-param>
               <ctl:with-param name="preferred-width">100</ctl:with-param>
@@ -2820,7 +2820,7 @@
             <ctl:call-function name="functions:layer-info">
               <ctl:with-param name="root-layer" select="$capabilities/wms:Capability/wms:Layer"/>
               <!-- select last layer in list -->
-              <ctl:with-param name="preferred-name" select="string($capabilities//wms:Layer[wms:Name and wms:Style/wms:Name = $style and position()=last()]/wms:Name)"/>
+              <ctl:with-param name="preferred-name" select="string($capabilities/descendant::wms:Layer[wms:Name and wms:Style/wms:Name = $style][last()]/wms:Name)"/>
               <ctl:with-param name="preferred-crs">CRS:84</ctl:with-param>
           <ctl:with-param name="preferred-bbox">-0.0025,-0.0025,0.0025,0.0025</ctl:with-param>
               <ctl:with-param name="preferred-width">100</ctl:with-param>
@@ -2889,7 +2889,7 @@
                 <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Title='cite:Lakes']/wms:Name)"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Name and functions:boolean-as-integer(@opaque)=0][1]/wms:Name)"/>
+                <xsl:value-of select="string(wms:Capability/descendant::wms:Layer[wms:Name and functions:boolean-as-integer(@opaque)=0][1]/wms:Name)"/>
               </xsl:otherwise>
             </xsl:choose>
           </ctl:with-param>
@@ -2960,7 +2960,7 @@
                 <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Title='cite:Lakes']/wms:Name)"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Name and functions:boolean-as-integer(@opaque)=0][1]/wms:Name)"/>
+                <xsl:value-of select="string(wms:Capability/descendant::wms:Layer[wms:Name and functions:boolean-as-integer(@opaque)=0][1]/wms:Name)"/>
               </xsl:otherwise>
             </xsl:choose>
           </ctl:with-param>
@@ -3145,7 +3145,7 @@
                 <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Title='cite:Lakes']/wms:Name)"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="string(wms:Capability//wms:Layer[not(number(@fixedWidth) &gt; 0) and not(number(@fixedHeight) &gt; 0)][1]/wms:Name)"/>
+                <xsl:value-of select="string(wms:Capability/descendant::wms:Layer[not(number(@fixedWidth) &gt; 0) and not(number(@fixedHeight) &gt; 0)][1]/wms:Name)"/>
               </xsl:otherwise>
             </xsl:choose>
           </ctl:with-param>
@@ -3233,7 +3233,7 @@
                 <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Title='cite:Lakes']/wms:Name)"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="string(wms:Capability//wms:Layer[not(number(@fixedWidth) &gt; 0) and not(number(@fixedHeight) &gt; 0)][1]/wms:Name)"/>
+                <xsl:value-of select="string(wms:Capability/descendant::wms:Layer[not(number(@fixedWidth) &gt; 0) and not(number(@fixedHeight) &gt; 0)][1]/wms:Name)"/>
               </xsl:otherwise>
             </xsl:choose>
           </ctl:with-param>
@@ -3307,7 +3307,7 @@
                 <xsl:value-of select="string(wms:Capability//wms:Layer[wms:Title='cite:Lakes']/wms:Name)"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="string(wms:Capability//wms:Layer[not(number(@fixedWidth) &gt; 0) and not(number(@fixedHeight) &gt; 0)][1]/wms:Name)"/>
+                <xsl:value-of select="string(wms:Capability/descendant::wms:Layer[not(number(@fixedWidth) &gt; 0) and not(number(@fixedHeight) &gt; 0)][1]/wms:Name)"/>
               </xsl:otherwise>
             </xsl:choose>
           </ctl:with-param>


### PR DESCRIPTION
The tests bbox-outside-crs and invalid-crs previously failed as the XPath was able to select more than one layer (see #15). This fix corrects the XPath expression to prevent selection of multiple layers.