### PR TITLE
Fix issue #20

### DIFF
--- a/src/main/scripts/ctl/getmap.xml
+++ b/src/main/scripts/ctl/getmap.xml
@@ -1128,7 +1128,7 @@
           <ctl:url>
             <xsl:value-of select="wms:Capability/wms:Request/wms:GetMap/wms:DCPType/wms:HTTP/wms:Get/wms:OnlineResource/@xlink:href"/>
           </ctl:url>
-          <ctl:method>get</ctl:method>
+          <ctl:method>GET</ctl:method>
           <ctl:param name="StYlEs"/>
           <ctl:param name="ReQuEsT">GetMap</ctl:param>
           <ctl:param name="HeIgHt">200</ctl:param>
@@ -1144,11 +1144,49 @@
           <ctl:param name="VeRsIoN">
             <xsl:value-of select="functions:version()"/>
           </ctl:param>
+          <parsers:HTTPParser>
+            <!-- ignore entity body -->
+            <parsers:parse><parsers:NullParser/></parsers:parse>
+          </parsers:HTTPParser>
         </ctl:request>
       </xsl:variable>
-      <xsl:if test="not($response/ogc:ServiceExceptionReport/ogc:ServiceException[@code='InvalidCRS'])">
-        <ctl:fail/>
-      </xsl:if>
+      <xsl:variable name="content-type" select="$response//header[functions:to-lowercase(@name) = 'content-type']"/>
+      <xsl:choose>
+        <xsl:when test="contains($content-type, '/xml')">
+          <!-- repeat request and check entity body -->
+          <xsl:variable name="response2">
+            <ctl:request>
+              <ctl:url>
+                <xsl:value-of select="wms:Capability/wms:Request/wms:GetMap/wms:DCPType/wms:HTTP/wms:Get/wms:OnlineResource/@xlink:href"/>
+              </ctl:url>
+              <ctl:method>GET</ctl:method>
+              <ctl:param name="StYlEs"/>
+              <ctl:param name="ReQuEsT">GetMap</ctl:param>
+              <ctl:param name="HeIgHt">200</ctl:param>
+              <ctl:param name="FoRmAt">
+                <xsl:value-of select="functions:encode($image-format)"/>
+              </ctl:param>
+              <ctl:param name="BbOx">-1,-1,1,1</ctl:param>
+              <ctl:param name="CrS">UndefinedCRS</ctl:param>
+              <ctl:param name="WiDtH">200</ctl:param>
+              <ctl:param name="LaYeRs">
+                <xsl:value-of select="functions:encode($layer)"/>
+              </ctl:param>
+              <ctl:param name="VeRsIoN">
+                <xsl:value-of select="functions:version()"/>
+              </ctl:param>
+            </ctl:request>
+          </xsl:variable>
+          <xsl:if test="not($response2//ogc:ServiceExceptionReport/ogc:ServiceException[@code='InvalidCRS'])">
+            <ctl:message>[FAIL] Expected ServiceException with code 'InvalidCRS'.</ctl:message>
+            <ctl:fail />
+          </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+          <ctl:message>[FAIL] Expected XML media type, but received Content-Type: '<xsl:value-of select="$content-type"/>'</ctl:message>
+          <ctl:fail />
+        </xsl:otherwise>
+      </xsl:choose>
     </ctl:code>
   </ctl:test>
 

--- a/src/site/markdown/relnotes.md
+++ b/src/site/markdown/relnotes.md
@@ -1,6 +1,10 @@
 WMS 1.3.0 Test Suite Release Notes
 ==================================
 
+## 1.14 (2015-MM-DD)
+* Fix [#20](https://github.com/opengeospatial/ets-wms13/issues/20): Malformed 
+  test results if response to `invalid-crs` test is not XML.
+
 1.13 (2015-09-24)
 ------------------
 * [#17](https://github.com/opengeospatial/ets-wms13/pull/17) - Fixed XPath to detect layer CRS (also consider root layer)


### PR DESCRIPTION
First check Content-Type header in response message (with `NullParser` so entity is ignored). Then resubmit request and check content of entity. Also added error messages.