### PR TITLE
Allow mimetype image/png in response when image/png with bit specification is requested

### DIFF
--- a/src/main/scripts/ctl/getmap.xml
+++ b/src/main/scripts/ctl/getmap.xml
@@ -1649,7 +1649,16 @@
         </ctl:request>
       </xsl:variable>
       <xsl:if test="functions:mime-match($response/response/headers/header[functions:to-lowercase(@name) = 'content-type'], $format) = 'false'">
-        <ctl:fail/>
+        <xsl:choose>
+          <xsl:when test="functions:mime-match($response/response/headers/header[functions:to-lowercase(@name) = 'content-type'], 'image/png') = 'true'">
+            <xsl:if test="contains($format, 'image/png') = 'false'">
+              <ctl:fail/>
+            </xsl:if>
+          </xsl:when>
+          <xsl:otherwise>
+            <ctl:fail/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
     </ctl:code>
   </ctl:test>

--- a/src/main/scripts/ctl/getmap.xml
+++ b/src/main/scripts/ctl/getmap.xml
@@ -1651,7 +1651,7 @@
       <xsl:if test="functions:mime-match($response/response/headers/header[functions:to-lowercase(@name) = 'content-type'], $format) = 'false'">
         <xsl:choose>
           <xsl:when test="functions:mime-match($response/response/headers/header[functions:to-lowercase(@name) = 'content-type'], 'image/png') = 'true'">
-            <xsl:if test="contains($format, 'image/png') = 'false'">
+            <xsl:if test="not(contains($format, 'image/png'))">
               <ctl:fail/>
             </xsl:if>
           </xsl:when>


### PR DESCRIPTION
Fix for #7

If the service provides support of image/png8 or image/png24 the response of a GetMap request with this image format may contain image/png.