### PR TITLE
Introduce limit of 10 for tested CRS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,10 @@
     <soapui.teamengine.endpoint>http://localhost:8081/teamengine</soapui.teamengine.endpoint>
     <soapui.teamengine.user>ogctest</soapui.teamengine.user>
     <soapui.teamengine.password>ogctest</soapui.teamengine.password>
-    <soapui.iut>http://cite.deegree.org/deegree-webservices-3.4.16/services/wms130?service=WMS&amp;request=GetCapabilities</soapui.iut>
-    <soapui.tests.passed>217</soapui.tests.passed>
+    <soapui.iut>https://cite.deegree.org/deegree-webservices-3.5.0/services/wms130?service=WMS&amp;request=GetCapabilities</soapui.iut>
+    <soapui.tests.passed>220</soapui.tests.passed>
     <soapui.tests.skipped>0</soapui.tests.skipped>
-    <soapui.tests.failed>1</soapui.tests.failed>
+    <soapui.tests.failed>0</soapui.tests.failed>
     <docker.teamengine.version>5.4.1</docker.teamengine.version>
   </properties>
 

--- a/src/main/scripts/ctl/getmap.xml
+++ b/src/main/scripts/ctl/getmap.xml
@@ -73,7 +73,7 @@
       <ctl:call-test name="getmap:invalid-crs"/>
       <xsl:variable name="capabilities" select="."/>
       <xsl:if test="$exhaustive != 'exhaustive'">
-        <ctl:for-each select="wms:Capability//wms:Layer//wms:CRS[not(. = ../preceding::wms:Layer/wms:CRS) and not(. = ../ancestor::wms:Layer/wms:CRS)]">
+        <ctl:for-each select="wms:Capability//wms:Layer//wms:CRS[not(. = ../preceding::wms:Layer/wms:CRS) and not(. = ../ancestor::wms:Layer/wms:CRS) and (position()=1 or position()=2 or position()=3 or position()=4 or position()=5 or position()=6 or position()=7 or position()=8 or position()=9 or position()=10)]">
           <ctl:call-test name="getmap:each-crs">
             <ctl:with-param name="capabilities" select="$capabilities"/>
             <ctl:with-param name="layer" select="(../descendant-or-self::wms:Layer[wms:Name])[1]/wms:Name"/>
@@ -999,7 +999,7 @@
     <ctl:comment/>
     <ctl:link title="WMS 1.3.0 section 7.3.3.3">http://cite.opengeospatial.org/OGCTestData/wms/1.3.0/spec/wms1_3.html#wmsops.getmap.params.layers</ctl:link>
     <ctl:code>
-      <ctl:for-each select="$capabilities/wms:Capability//wms:Layer[wms:Name=$layer]/ancestor-or-self::wms:Layer/wms:CRS[not(. = ../ancestor::wms:Layer/wms:CRS)]">
+      <ctl:for-each select="$capabilities/wms:Capability//wms:Layer[wms:Name=$layer]/ancestor-or-self::wms:Layer/wms:CRS[not(. = ../ancestor::wms:Layer/wms:CRS) and (position()=1 or position()=2 or position()=3 or position()=4 or position()=5 or position()=6 or position()=7 or position()=8 or position()=9 or position()=10)]">
         <ctl:call-test name="getmap:each-crs">
           <ctl:with-param name="capabilities" select="$capabilities"/>
           <ctl:with-param name="layer" select="$layer"/>


### PR DESCRIPTION
This pull request limits the number of GetMap requests for different CRS to 10.
The aim is to improve the performance of the test suite and to prevent possible memory errors.

Also, the soapui properties used by integration tests were updated.

Related to https://github.com/opengeospatial/ets-wms11/pull/84