### PR TITLE
Fix test queryable:std-data-queryable

### DIFF
--- a/src/main/scripts/ctl/queryable.xml
+++ b/src/main/scripts/ctl/queryable.xml
@@ -252,7 +252,7 @@
          </xsl:variable>
          <xsl:for-each select="$names/name">
             <xsl:variable name="name" select="."/>
-            <xsl:variable name="layer" select="$root-layer/descendant-or-self::wms:Layer[wms:Name = $name or wms:Name = cite: + $name]"/>
+            <xsl:variable name="layer" select="$root-layer/descendant-or-self::wms:Layer[wms:Name = $name or wms:Name = concat('cite:', $name)]"/>
             <xsl:choose>
                <xsl:when test="not($layer/wms:Name)">
                   <ctl:message>Error: No layer named <xsl:value-of select="$name"/> found.</ctl:message>


### PR DESCRIPTION
XPath expression was broken and replaced by a correct expression:
* Broken: `wms:Name = cite: + $name`
* Corrected: `wms:Name = concat('cite:', $name)`

This bug was discovered in https://github.com/opengeospatial/teamengine/pull/593.